### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,11 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)
 find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PATH)
 
-
-project(CUDAProb3 LANGUAGES CXX C CUDA)
+if(${CPU_ONLY})
+  project(CUDAProb3 LANGUAGES CXX C)
+else()
+  project(CUDAProb3 LANGUAGES CXX C CUDA)
+endif()
 
 #Changes default install path to be a subdirectory of the build dir.
 #Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
@@ -22,52 +25,66 @@ elseif(NOT DEFINED CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RELWITHDEBINFO)
 endif()
 
-SET(HEADERS_BEAM beamcudapropagator.cuh)
-SET(HEADERS_ATMOS atmoscudapropagator.cuh)
 
- 
-SET(SOURCE_BEAM beamcudapropagator.cu)
-SET(SOURCE_ATMOS atmoscudapropagator.cu)
+if(${CPU_ONLY})
+
+  add_library(CUDAProb3Beam INTERFACE)
+  add_library(CUDAProb3Atmos INTERFACE)
+
+  target_include_directories(CUDAProb3Beam INTERFACE ${PROJECT_SOURCE_DIR})
+  target_include_directories(CUDAProb3Atmos INTERFACE ${PROJECT_SOURCE_DIR})
+
+else()
 
 
-add_library(CUDAProb3Beam SHARED ${SOURCE_BEAM})
-add_library(CUDAProb3Atmos SHARED ${SOURCE_ATMOS})
+  SET(HEADERS_BEAM beamcudapropagator.cuh)
+  SET(HEADERS_ATMOS atmoscudapropagator.cuh)
+  
+   
+  SET(SOURCE_BEAM beamcudapropagator.cu)
+  SET(SOURCE_ATMOS atmoscudapropagator.cu)
+  
+  
+  add_library(CUDAProb3Beam SHARED ${SOURCE_BEAM})
+  add_library(CUDAProb3Atmos SHARED ${SOURCE_ATMOS})
+  
+  set_target_properties(CUDAProb3Beam PROPERTIES 
+  	PUBLIC_HEADER "${HEADERS_BEAM}"
+  	EXPORT_NAME CUDAProb3Beam
+          CUDA_SEPARABLE_COMPILATION ON 
+          LINKER_LANGUAGE CUDA)
+  
+  set_target_properties(CUDAProb3Atmos PROPERTIES 
+  	PUBLIC_HEADER "${HEADERS_ATMOS}"
+  	EXPORT_NAME CUDAProb3Atmos
+          CUDA_SEPARABLE_COMPILATION ON 
+          LINKER_LANGUAGE CUDA)
+  
+  set_property(TARGET CUDAProb3Beam PROPERTY CUDA_ARCHITECTURES 35 52 60 61 70 75)
+  set_property(TARGET CUDAProb3Atmos PROPERTY CUDA_ARCHITECTURES 35 52 60 61 70 75)
+  
+  target_include_directories(
+    CUDAProb3Beam PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                         $<INSTALL_INTERFACE:include>
+  )
+  
+  target_include_directories(
+    CUDAProb3Atmos PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                         $<INSTALL_INTERFACE:include>
+  )
+  
+  install(TARGETS CUDAProb3Beam CUDAProb3Atmos 
+  		EXPORT CUDAProb3-target
+  		LIBRARY DESTINATION lib/
+  		PUBLIC_HEADER DESTINATION include/)
+  
+  install(EXPORT CUDAProb3-target
+    FILE CUDAProb3Targets.cmake
+    NAMESPACE CUDAProb3::
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/CUDAProb3
+  )
 
-set_target_properties(CUDAProb3Beam PROPERTIES 
-	PUBLIC_HEADER "${HEADERS_BEAM}"
-	EXPORT_NAME CUDAProb3Beam
-        CUDA_SEPARABLE_COMPILATION ON 
-        LINKER_LANGUAGE CUDA)
-
-set_target_properties(CUDAProb3Atmos PROPERTIES 
-	PUBLIC_HEADER "${HEADERS_ATMOS}"
-	EXPORT_NAME CUDAProb3Atmos
-        CUDA_SEPARABLE_COMPILATION ON 
-        LINKER_LANGUAGE CUDA)
-
-set_property(TARGET CUDAProb3Beam PROPERTY CUDA_ARCHITECTURES 35 52 60 61 70 75 80 86)
-set_property(TARGET CUDAProb3Atmos PROPERTY CUDA_ARCHITECTURES 35 52 60 61 70 75 80 86)
-
-target_include_directories(
-  CUDAProb3Beam PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                       $<INSTALL_INTERFACE:include>
-)
-
-target_include_directories(
-  CUDAProb3Atmos PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                       $<INSTALL_INTERFACE:include>
-)
-
-install(TARGETS CUDAProb3Beam CUDAProb3Atmos 
-		EXPORT CUDAProb3-target
-		LIBRARY DESTINATION lib/
-		PUBLIC_HEADER DESTINATION include/)
-
-install(EXPORT CUDAProb3-target
-  FILE CUDAProb3Targets.cmake
-  NAMESPACE CUDAProb3::
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/CUDAProb3
-)
+endif()
 
 #include(CMakePackageConfigHelpers)
 #configure_package_config_file(

--- a/atmoscudapropagator.cuh
+++ b/atmoscudapropagator.cuh
@@ -19,8 +19,8 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 #include "atmoscpupropagator.hpp"
 #include "physics.hpp"
 
-//#ifdef __NVCC__  //change this to ifndef __NVCC__ before running doxygen. otherwise both classes are not included in the documentation
-#ifndef CPU_ONLY 
+#ifdef __NVCC__  //change this to ifndef __NVCC__ before running doxygen. otherwise both classes are not included in the documentation
+//#ifndef CPU_ONLY 
 
 #ifndef CUDAPROB3_ATMOSCUDAPROPAGATOR_CUH
 #define CUDAPROB3_ATMOSCUDAPROPAGATOR_CUH

--- a/beamcudapropagator.cuh
+++ b/beamcudapropagator.cuh
@@ -19,8 +19,8 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamcpupropagator.hpp"
 #include "physics.hpp"
 
-//#ifdef __NVCC__ //change this to ifndef __NVCC__ before running doxygen. otherwise both classes are not included in the documentation
-#ifndef CPU_ONLY
+#ifdef __NVCC__ //change this to ifndef __NVCC__ before running doxygen. otherwise both classes are not included in the documentation
+//#ifndef CPU_ONLY
 
 #ifndef CUDAPROB3_BEAMCUDAPROPAGATOR_HPP
 #define CUDAPROB3_BEAMCUDAPROPAGATOR_HPP

--- a/physics.hpp
+++ b/physics.hpp
@@ -1163,7 +1163,6 @@ namespace cudaprob3{
         prepare_getMfast<FLOAT_T>(type);
 #endif
         // Save some memory and access by defining these here
-        const int nExp = 3;
         const int nNuFlav = 3;
 
 #ifdef __CUDA_ARCH__


### PR DESCRIPTION
Removing CUDA dependency if using the cmake flag CPU_ONLY -> CUDAProb builds as header-only library

Event rate before:

FHC_numu unosc: 25941.57467
FHC_numu osc: 7979.64829

FHC_nue unosc: 391.59946
FHC_nue osc: 1702.14708

RHC_numu unosc: 12492.61743
RHC_numu osc: 4219.10087

RHC_nue unosc: 208.80159
RHC_nue osc: 447.97657

Event rate after:

FHC_numu unosc: 25941.57467
FHC_numu osc: 7979.64829

FHC_nue unosc: 391.59946
FHC_nue osc: 1702.14708

RHC_numu unosc: 12492.61743
RHC_numu osc: 4219.10087

RHC_nue unosc: 208.80159
RHC_nue osc: 447.97657