### PR TITLE
CUDA Propagator Thread Passthrough

### DIFF
--- a/beamcudapropagator.cu
+++ b/beamcudapropagator.cu
@@ -26,7 +26,7 @@ along with CUDAProb3++.  If not, see <http://www.gnu.org/licenses/>.
         ///
         /// @param id device id of the GPU to use
         /// @param n_energies_ Number of energy bins
-        cudaprob3::BeamCudaPropagatorSingle::BeamCudaPropagatorSingle(int id, int n_energies_) : cudaprob3::BeamCpuPropagator<double>(n_energies_, 1), deviceId(id){
+        cudaprob3::BeamCudaPropagatorSingle::BeamCudaPropagatorSingle(int id, int n_energies_, int n_threads_) : cudaprob3::BeamCpuPropagator<double>(n_energies_, n_threads_), deviceId(id){
 
             int nDevices;
 

--- a/beamcudapropagator.cuh
+++ b/beamcudapropagator.cuh
@@ -48,7 +48,8 @@ namespace cudaprob3{
         /// @param id device id of the GPU to use
         /// @param n_cosines_ Number cosine bins
         /// @param n_energies_ Number of energy bins
-        BeamCudaPropagatorSingle(int id, int n_energies_); 
+	/// @param n_threads_ Number of threads
+        BeamCudaPropagatorSingle(int id, int n_energies_, int n_threads_); 
 
         /// \brief Constructor which uses device id 0
         ///


### PR DESCRIPTION
Pass through the number of OMP threads to use whilst using GPU propagator so we don't get stuck with using single thread when GPU is used